### PR TITLE
erlang.mk compatibility

### DIFF
--- a/ebin/iso8601.app
+++ b/ebin/iso8601.app
@@ -1,7 +1,0 @@
-{application,iso8601,
-             [{description,"ISO 8601 date parser and formatter."},
-              {vsn,"1.1.1"},
-              {registered,[]},
-              {applications,[kernel,stdlib]},
-              {env,[]},
-              {modules,[iso8601]}]}.

--- a/src/iso8601.app.src
+++ b/src/iso8601.app.src
@@ -2,6 +2,7 @@
  [
   {description, "ISO 8601 date parser and formatter."},
   {vsn, "1.1.1"},
+  {modules, []},
   {registered, []},
   {applications, [kernel, stdlib]},
   {env, []}


### PR DESCRIPTION
Empty "modules" in iso8601.app.src + removed ebin.
It was not clear why do you have ebin in the repository