### PR TITLE
Support parsing microseconds with a parse_exact/1 function

### DIFF
--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -2,7 +2,8 @@
 
 -export([add_time/4,
          format/1,
-         parse/1]).
+         parse/1,
+         parse_exact/1]).
 
 -export_types([datetime/0,
                timestamp/0]).
@@ -41,11 +42,19 @@ format({{Y,Mo,D}, {H,Mn,S}}) ->
     list_to_binary(IsoStr).
 
 -spec parse (string()) -> datetime().
-%% @doc Convert an ISO 8601 formatted string to a 
+%% @doc Convert an ISO 8601 formatted string to a `{date(), time()}' tuple
 parse(Bin) when is_binary(Bin) ->
     parse(binary_to_list(Bin));
 parse(Str) ->
-    year(Str, []).
+    {{Date, {H, M, S}}, Subsecond} = year(Str, []),
+    {Date, {H, M, S + round(Subsecond)}}.
+
+-spec parse_exact (string()) -> datetime().
+%% @doc Convert an ISO 8601 formatted string to a `{date(), time()}'
+%% tuple with seconds precision to 3 decimal palces
+parse_exact(Str) ->
+    {{Date, {H, M, S}}, SecondsDecimal} = year(Str, []),
+    {Date, {H, M, S + SecondsDecimal}}.
 
 %% Private functions
 
@@ -196,8 +205,8 @@ acc_float(FloatStr, Rest, Key, Acc, NextF) ->
 add_decimal(Datetime, Plist) ->
     HDecimal = ?V(hour_decimal, Plist, 0.0),
     MDecimal = ?V(minute_decimal, Plist, 0.0),
-    SDecimal = ?V(second_decimal, Plist, 0.0),
-    apply_offset(Datetime, HDecimal, MDecimal, SDecimal).
+%%    SDecimal = ?V(second_decimal, Plist, 0.0),
+    apply_offset(Datetime, HDecimal, MDecimal, 0.0).
 
 datetime(Plist) ->
     {Date, WeekOffsetH} = make_date(Plist),
@@ -206,7 +215,8 @@ datetime(Plist) ->
     OffsetSign = ?V(offset_sign, Plist, 1),
     OffsetH = -1 * OffsetSign * ?V(offset_hour, Plist, 0),
     OffsetM = -1 * OffsetSign * ?V(offset_minute, Plist, 0),
-    apply_offset(Datetime, WeekOffsetH+OffsetH, OffsetM, 0).
+    { apply_offset(Datetime, WeekOffsetH+OffsetH, OffsetM, 0), ?V(second_decimal, Plist, 0.0) }.
+
 
 datetime(_, Plist) ->
     datetime(Plist).

--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -52,6 +52,8 @@ parse(Str) ->
 -spec parse_exact (string()) -> datetime().
 %% @doc Convert an ISO 8601 formatted string to a `{date(), time()}'
 %% tuple with seconds precision to 3 decimal palces
+parse_exact(Bin) when is_binary(Bin) ->
+    parse_exact(binary_to_list(Bin));
 parse_exact(Str) ->
     {{Date, {H, M, S}}, SecondsDecimal} = year(Str, []),
     {Date, {H, M, S + SecondsDecimal}}.


### PR DESCRIPTION
Tried to make this as non-invasive and backwards compatible as possible. I need the ability to parse exact dates out for later reformating ... this makes it trivial to go from string containing an iso8601 datetime with tz to a string in UTC: 

1> iso8601:format(iso8601:parse_exact("2015-02-23T14:59:49.717+01:00")).
<<"2015-02-23T13:59:49.717Z">>

Am happy to make adjustment as needed.