### PR TITLE
add required fields for adding to hex.pm

### DIFF
--- a/src/iso8601.app.src
+++ b/src/iso8601.app.src
@@ -4,4 +4,9 @@
               {registered,[]},
               {modules,[iso8601,iso8601_tests]},
               {applications,[kernel,stdlib]},
-              {env,[]}]}.
+              {env,[]},
+              {licenses, ["BSD"]},
+              {maintainers, ["Duncan McGreggor"]},
+              {links, [{"Github", "https://github.com/erlsci/iso8601"}]}
+             ]
+}.


### PR DESCRIPTION
Would be very nice to be able to use this package from hex.pm for projects using rebar3 or mix. This patch adds the required fields ... if merged, I would be happy to add it to hex.pm, though it would probably be more sensible if the upstream maintainers did so.