### PR TITLE
Fixed a typo and omission in EDoc comments

### DIFF
--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -39,7 +39,7 @@ format({{Y,Mo,D}, {H,Mn,S}}) ->
     list_to_binary(IsoStr).
 
 -spec parse (iodata()) -> calendar:datetime().
-%% @doc Convert an ISO 8601 formatted string to a
+%% @doc Convert an ISO 8601 formatted string to a `{date(), time()}'
 parse(Bin) when is_binary(Bin) ->
     parse(binary_to_list(Bin));
 parse(Str) ->
@@ -48,7 +48,7 @@ parse(Str) ->
 
 -spec parse_exact (iodata()) -> calendar:datetime().
 %% @doc Convert an ISO 8601 formatted string to a `{date(), time()}'
-%% tuple with seconds precision to 3 decimal palces
+%% tuple with seconds precision to 3 decimal places
 parse_exact(Bin) when is_binary(Bin) ->
     parse_exact(binary_to_list(Bin));
 parse_exact(Str) ->


### PR DESCRIPTION
This is a very minor PR.

I was browsing the code and noticed a typo in one EDoc comment, and an incomplete comment in another EDoc comment.