### PR TITLE
Added subtract_time function, with tests and example usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# iso8601 
-[![Build Status][travis-badge]][travis] 
-[![Tag][tag-badge]][tag] 
+# iso8601
+[![Build Status][travis-badge]][travis]
+[![Tag][tag-badge]][tag]
 [![Erlang Version][erl-badge]][erl]
 [![Downloads][hex downloads]][hex package]
 
@@ -68,6 +68,15 @@ Add 1 hour, 2 minutes and 3 seconds to a datetime tuple:
 {{2012,2,16},{1,6,48}}
 6> iso8601:add_time(Datetime, 1, 2, 3).
 {{2012,2,16},{2,8,51}}
+```
+
+Subtract 1 hour, 2 minutes and 3 seconds from a datetime tuple:
+
+```erlang
+5> Datetime = iso8601:parse(<<"2012-02-16T01:06:48Z">>).
+{{2012,2,16},{1,6,48}}
+6> iso8601:subtract_time(Datetime, 1, 2, 3).
+{{2012,2,16},{0,4,45}}
 ```
 
 Fractional times:

--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -1,6 +1,7 @@
 -module(iso8601).
 
 -export([add_time/4,
+         subtract_time/4,
          format/1,
          parse/1,
          parse_exact/1]).
@@ -25,6 +26,12 @@
 %% @doc Add some time to the supplied `calendar:datetime()'.
 add_time(Datetime, H, M, S) ->
     apply_offset(Datetime, H, M, S).
+
+-spec subtract_time (calendar:datetime(), integer(), integer(), integer())
+                    -> calendar:datetime().
+%% @doc Subtract some time from the supplied `calendar:datetime()'.
+subtract_time(Datetime, H, M, S) ->
+    apply_offset(Datetime, -H, -M, -S).
 
 -spec format (datetime() | timestamp()) -> binary().
 %% @doc Convert a `util:timestamp()' or a calendar-style `{date(), time()}'

--- a/test/iso8601_tests.erl
+++ b/test/iso8601_tests.erl
@@ -160,3 +160,19 @@ parse_ordinal_exact_test_() ->
      {"parses ordinal date wth 366 days in a leap year", ?_assertMatch({{2016,12,31}, {4,5,6.50}}, F("2016-366T040506.50"))},
      {"fails to parse ordinal date with too many days in a non-leap year", ?_assertError(badarg, F("2015-366T040506.50"))}
     ].
+
+add_time_test_() ->
+    F= fun iso8601:add_time/4,
+    [{"add one second", ?_assertMatch({{2017,11,28}, {17,7,58}}, F({{2017,11,28}, {17,7,57}}, 0, 0, 1))},
+     {"add one minute", ?_assertMatch({{2017,11,28}, {17,8,57}}, F({{2017,11,28}, {17,7,57}}, 0, 1, 0))},
+     {"add one hour", ?_assertMatch({{2017,11,28}, {18,7,57}}, F({{2017,11,28}, {17,7,57}}, 1, 0, 0))},
+     {"roll over to next day", ?_assertMatch({{2017,11,29}, {00,30,00}}, F({{2017,11,28}, {23,30,00}}, 1, 0, 0))}
+    ].
+
+subtract_time_test_() ->
+    F= fun iso8601:subtract_time/4,
+    [{"add one second", ?_assertMatch({{2017,11,28}, {17,7,56}}, F({{2017,11,28}, {17,7,57}}, 0, 0, 1))},
+     {"add one minute", ?_assertMatch({{2017,11,28}, {17,6,57}}, F({{2017,11,28}, {17,7,57}}, 0, 1, 0))},
+     {"add one hour", ?_assertMatch({{2017,11,28}, {16,7,57}}, F({{2017,11,28}, {17,7,57}}, 1, 0, 0))},
+     {"roll back to previous day", ?_assertMatch({{2017,11,28}, {23,30,00}}, F({{2017,11,29}, {00,30,00}}, 1, 0, 0))}
+    ].


### PR DESCRIPTION
This is a fix for issue #38.

* Added a new `subtract_time` function, to complement the existing `add_time` function.
* Added a few EUnit tests around both functions.
* Updated the readme file with a sample usage, similar to the `add_time` function.