### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
 env: PATH=".:$PATH"
 script: make check
 otp_release:
+  - 23.0
+  - 22.3
+  - 21.3
   - 20.1
   - 19.3
   - 18.3

--- a/test/iso8601_tests.erl
+++ b/test/iso8601_tests.erl
@@ -95,13 +95,13 @@ parse_second_test_() ->
 parse_fractional_second_test_() ->
     F = fun iso8601:parse/1,
     [{"parses YYYYMMDDTHHMMSS.ss",
-      ?_assertMatch({{2012,2,3},{4,5,7}}, F("20120203T040506.50"))},
+      ?_assertMatch({{2012,2,3},{4,5,6}}, F("20120203T040506.50"))},
      {"parses YYYY-MM-DDTHHMMSS.ss",
-      ?_assertMatch({{2012,2,3},{4,5,7}}, F("2012-02-03T040506.50"))},
+      ?_assertMatch({{2012,2,3},{4,5,6}}, F("2012-02-03T040506.50"))},
      {"parses YYYYMMDDTHHMMSS,ss",
-      ?_assertMatch({{2012,2,3},{4,5,7}}, F("20120203T040506,50"))},
+      ?_assertMatch({{2012,2,3},{4,5,6}}, F("20120203T040506,50"))},
      {"parses YYYY-MM-DDTHHMMSS,ss",
-      ?_assertMatch({{2012,2,3},{4,5,7}}, F("2012-02-03T040506,50"))}].
+      ?_assertMatch({{2012,2,3},{4,5,6}}, F("2012-02-03T040506,50"))}].
 
 parse_exact_fractional_second_test_() ->
     F = fun iso8601:parse_exact/1,
@@ -122,11 +122,11 @@ parse_fractional_fail_test_() ->
 parse_offset_test_() ->
     F = fun iso8601:parse/1,
     [{"parses YYYYMMDDTHHMMSS.ssZ",
-      ?_assertMatch({{2012,2,3},{4,5,7}}, F("20120203T040506.50Z"))},
+      ?_assertMatch({{2012,2,3},{4,5,6}}, F("20120203T040506.50Z"))},
      {"parses YYYYMMDDTHHMMSS.ss+0400",
-      ?_assertMatch({{2012,2,3},{15,9,7}}, F("20120203T200506.50+0456"))},
+      ?_assertMatch({{2012,2,3},{15,9,6}}, F("20120203T200506.50+0456"))},
      {"parses YYYYMMDDTHHMMSS.ss+0400",
-      ?_assertMatch({{2012,2,3},{17,11,7}}, F("20120203T040506.50-1306"))}].
+      ?_assertMatch({{2012,2,3},{17,11,6}}, F("20120203T040506.50-1306"))}].
 
 parse_duration_test_() ->
      F = fun iso8601:parse_duration/1,
@@ -154,17 +154,17 @@ parse_duration_fail_test_() ->
 
 parse_ordinal_test_() ->
     F= fun iso8601:parse/1,
-    [{"parses YYYY-DDDTHHMMSS", ?_assertMatch({{2016,2,3}, {4,5,7}}, F("2016-034T040506.50")) },
+    [{"parses YYYY-DDDTHHMMSS", ?_assertMatch({{2016,2,3}, {4,5,6}}, F("2016-034T040506.50")) },
      {"parses YYYY-DDD", ?_assertMatch({{2016,2,3}, ?MN}, F("2016-034")) },
-     {"parses YYYY_DDDTHHMMSS, Feb 29 in a leap year", ?_assertMatch({{2016,2,29}, {4,5,7}}, F("2016-060T040506.50")) },
-     {"parses YYYY_DDDTHHMMSS, after Feb 29 in a leap year", ?_assertMatch({{2016,9,25}, {4,5,7}}, F("2016-269T040506.50")) },
-     {"parses YYYY_DDDTHHMMSS, Feb 29 in a leap century", ?_assertMatch({{2000,2,29}, {4,5,7}}, F("2000-060T040506.50")) },
-     {"parses YYYY_DDDTHHMMSS, March 1 in a non-leap year", ?_assertMatch({{2015,3,1}, {4,5,7}}, F("2015-060T040506.50")) },
-     {"parses YYYY_DDDTHHMMSS, after Feb 29 in a non-leap year", ?_assertMatch({{2015,9,26}, {4,5,7}}, F("2015-269T040506.50")) },
-     {"parses YYYY_DDDTHHMMSS, March 1 in a non-leap century", ?_assertMatch({{1900,3,1}, {4,5,7}}, F("1900-060T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, Feb 29 in a leap year", ?_assertMatch({{2016,2,29}, {4,5,6}}, F("2016-060T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, after Feb 29 in a leap year", ?_assertMatch({{2016,9,25}, {4,5,6}}, F("2016-269T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, Feb 29 in a leap century", ?_assertMatch({{2000,2,29}, {4,5,6}}, F("2000-060T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, March 1 in a non-leap year", ?_assertMatch({{2015,3,1}, {4,5,6}}, F("2015-060T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, after Feb 29 in a non-leap year", ?_assertMatch({{2015,9,26}, {4,5,6}}, F("2015-269T040506.50")) },
+     {"parses YYYY_DDDTHHMMSS, March 1 in a non-leap century", ?_assertMatch({{1900,3,1}, {4,5,6}}, F("1900-060T040506.50")) },
      {"fails to parse ordinal date with 0 days", ?_assertError(badarg, F("2016-000T040506.50"))},
      {"fails to parse ordinal date with too many days in a leap year", ?_assertError(badarg, F("2016-367T040506.50"))},
-     {"parses ordinal date wth 366 days in a leap year", ?_assertMatch({{2016,12,31}, {4,5,7}}, F("2016-366T040506.50"))},
+     {"parses ordinal date wth 366 days in a leap year", ?_assertMatch({{2016,12,31}, {4,5,6}}, F("2016-366T040506.50"))},
      {"fails to parse ordinal date with too many days in a non-leap year", ?_assertError(badarg, F("2015-366T040506.50"))}
     ].
 


### PR DESCRIPTION
If I understand this correctly, the previous change (53bd46f) was accepted as OK, which means that the fix I propose (following that change, incomplete) will not be surprising.

At the same time, I extend the Travis/Erlang versions to use, as to guarantee code checks are as "updated" as possible.

**Note**: tests are failing for (older) Erlang/OTP 15, 16, and 17, but the Travis logs aren't helping much.