### PR TITLE
Properly export types

### DIFF
--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -20,7 +20,7 @@
 %% Types
 %%----------------------------------------------------------------------
 
--export_types([timestamp/0, year/0, month/0, day/0, hour/0, minute/0, second/0]).
+-export_type([timestamp/0, year/0, month/0, day/0, hour/0, minute/0, second/0]).
 
 %% This group of types is from calendar.erl; we need to use some of them
 %% for this  lib, but thought it might be nice to provide the rest to users.


### PR DESCRIPTION
I got this from a compile-time warning

```erlang
src/iso8601.erl:27:2: Warning: type year() is unused
src/iso8601.erl:28:2: Warning: type month() is unused
src/iso8601.erl:29:2: Warning: type day() is unused
```